### PR TITLE
feat: support scientific notation

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -18,7 +18,7 @@ import {
   VALUE_ILLEGAL_ERROR_MESSAGE
 } from './contant';
 
-const NUMBER_REGX = /^[-|+]?([0-9]+\.?\d*)/;
+const NUMBER_REGX = /^[-+]?([0-9]+\.?\d*)([Ee][-+]?[0-9]+)?/;
 
 function getCursor(context: ParserContext) {
   const { offset, column, line } = context;
@@ -211,7 +211,7 @@ function parseUndefined(context: ParserContext) {
 function parseValue(context: ParserContext) {
   let value = null;
   let type = null;
-  let code = context.source[0];
+  let code = context.source[0];  
   if (NUMBER_REGX.test(context.source)) {
     value = parseNumber(context);
     type = NUMBER_TYPE;

--- a/tests/compile.test.ts
+++ b/tests/compile.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, expect, test, it } from 'vitest';
-import json2ts from '../src';
+import json2ts, { VALUE_ILLEGAL_ERROR_MESSAGE } from '../src';
 
 // Edit an assertion and save to see HMR in action
 
@@ -472,3 +472,29 @@ describe("parse number with digit", () => {
     `)
   })
 })
+
+describe("scientific notation", () => {
+  it("compile scientific notation", () => {
+    expect(json2ts(`{num: 3.14E+10}`)).toMatchInlineSnapshot(`
+      "type Result\$0Type = {
+        num: number
+      }
+      "
+    `);
+  });
+
+  it("compile scientific notation with -", () => {
+    expect(json2ts(`{num: 2.71828e-05}`)).toMatchInlineSnapshot(`
+      "type Result\$0Type = {
+        num: number
+      }
+      "
+    `);
+  });
+
+  it("JSON does not support scientific notation starting with decimal point", () => {
+    expect(() => json2ts(`{num: .71828e-05}`)).toThrowError(
+      VALUE_ILLEGAL_ERROR_MESSAGE
+    );
+  });
+});


### PR DESCRIPTION
支持解析科学记数法：
支持`3.14E+10`和`2.71828e-05`，如`.71828e-05`不符合JSON数字语法则抛出异常
参考[JSON数字语法](https://github.com/miloyip/json-tutorial/blob/master/tutorial02/tutorial02.md#2-json-%E6%95%B0%E5%AD%97%E8%AF%AD%E6%B3%95)